### PR TITLE
add syncing and synced events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /vendor
 /.idea
 composer.lock

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ We thank the following sponsors for their generosity. Please take a moment to ch
 You can check all eloquent events here:  https://laravel.com/docs/5.8/eloquent#events) 
 
 New events are :
+- `pivotSyncing`, `pivotSynced`
 - `pivotAttaching`, `pivotAttached`
 - `pivotDetaching`, `pivotDetached`
 - `pivotUpdating`, `pivotUpdated`
@@ -50,6 +51,14 @@ The easiest way to catch events is using methods in your model's `boot()` method
 public static function boot()
 {
     parent::boot();
+
+    static::pivotSyncing(function ($model, $relationName) {
+        //
+    });
+     
+    static::pivotSynced(function ($model, $relationName, $changes) {
+        //
+    });
 
     static::pivotAttaching(function ($model, $relationName, $pivotIds, $pivotIdsAttributes) {
         //
@@ -107,10 +116,10 @@ Dispatches **one** **pivotUpdating** and **one** **pivotUpdated** event.
 You can change only one row in the pivot table with updateExistingPivot.   
 
 **sync()**  
-Dispatches **more** **pivotAttaching** and **more** **pivotAttached** events, depending on how many rows are added in the pivot table. These events are not dispatched if nothing is attached.  
-Dispatches **one** **pivotDetaching** and **one** **pivotDetached** event, but you can see all deleted ids in the $pivotIds variable. This event is not dispatched if nothing is detached.  
-E.g. when you call sync() if two rows are added and two are deleted **two** **pivotAttaching** and **two** **pivotAttached** events and **one** **pivotDetaching** and **one** **pivotDetached** event will be dispatched.  
-If sync() is called but rows are not added or deleted events are not dispatched.  
+Dispatches **one** **pivotSyncing** and **one** **pivotSynced** event.  
+Whether a row was attached/detached/updated during sync only **one** event is dispatched for all rows but in that case, you can see all the attached/detached/updated rows in the $changes variables.  
+E.g. *How does sync work:* The sync first detaches all associations and then attaches or updates new entries one by one.
+
 
 
 ## Usage
@@ -129,6 +138,13 @@ class User extends Model
     {
         return $this->belongsToMany(Role::class);
     }
+    
+    static::pivotSynced(function ($model, $relationName, $changes) {
+         echo 'pivotAttached';
+         echo get_class($model);
+         echo $relationName;
+         print_r($changes);
+     });
     
     static::pivotAttached(function ($model, $relationName, $pivotIds, $pivotIdsAttributes) {
         echo 'pivotAttached';

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         }
     ],
     "require": {
-        "illuminate/database": "^9.0",
-        "illuminate/support": "^9.0"
+        "illuminate/database": "^8.0|^9.0",
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.0",

--- a/src/Traits/FiresPivotEventsTrait.php
+++ b/src/Traits/FiresPivotEventsTrait.php
@@ -6,6 +6,30 @@ use Illuminate\Database\Eloquent\Collection;
 trait FiresPivotEventsTrait
 {
     /**
+     * Sync the intermediate tables with a list of IDs or collection of models.
+     *
+     * @param mixed $ids
+     * @param bool $detaching
+     *
+     * @return array
+     */
+    public function sync($ids, $detaching = true)
+    {
+        if (false === $this->parent->fireModelEvent('pivotSyncing', true, $this->getRelationName())) {
+            return false;
+        }
+
+        $parentResult = [];
+        $this->parent->withoutEvents(function () use ($ids, $detaching, &$parentResult) {
+            $parentResult = parent::sync($ids, $detaching);
+        });
+
+        $this->parent->fireModelEvent('pivotSynced', false, $this->getRelationName(), $parentResult);
+
+        return $parentResult;
+    }
+
+    /**
      * Attach a model to the parent.
      *
      * @param mixed $id

--- a/src/Traits/PivotEventTrait.php
+++ b/src/Traits/PivotEventTrait.php
@@ -15,12 +15,23 @@ trait PivotEventTrait
         return array_merge(
             parent::getObservableEvents(),
             [
+                'pivotSyncing', 'pivotSynced',
                 'pivotAttaching', 'pivotAttached',
                 'pivotDetaching', 'pivotDetached',
                 'pivotUpdating', 'pivotUpdated',
             ],
             $this->observables
         );
+    }
+
+    public static function pivotSyncing($callback, $priority = 0)
+    {
+        static::registerModelEvent('pivotSyncing', $callback, $priority);
+    }
+
+    public static function pivotSynced($callback, $priority = 0)
+    {
+        static::registerModelEvent('pivotSynced', $callback, $priority);
     }
 
     public static function pivotAttaching($callback, $priority = 0)


### PR DESCRIPTION
## Context

The Sync method uses behind the scenes first detach to detach all associations and then will use attachNew for each new entry, which leads to a lot of events being dispatched.

## What did I do

- Add syncing and synced events
- Pass the results of sync to the dispatched event
- Support both Laravel 8 and 9
- Update README